### PR TITLE
Support escaped path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ $(GO_DEPS): go.mod $(PATCHES)
 	patch -d vendor -p0 < patches/gnmi_set.patch
 	patch -d vendor -p0 < patches/gnmi_get.patch
 	patch -d vendor -p0 < patches/gnmi_path.patch
+	patch -d vendor -p0 < patches/gnmi_xpath.patch
 	touch $@
 
 go-deps: $(GO_DEPS)

--- a/patches/gnmi_xpath.patch
+++ b/patches/gnmi_xpath.patch
@@ -1,0 +1,21 @@
+Use escaped '/' to support ip prefix in path element
+--- ./github.com/jipanyang/gnxi/utils/xpath/xpath.go
++++ ./github.com/jipanyang/gnxi/utils/xpath/xpath.go
+@@ -88,11 +88,15 @@
+ 	for end < len(str) {
+ 		switch str[end] {
+ 		case '/':
+-			if !insideBrackets {
++			if end != 0 && str[end-1] == '\\' {
++				// Ignore escaped '/'
++				end++
++			} else if !insideBrackets {
+ 				// Current '/' is a valid path element
+ 				// separator.
+ 				if end > begin {
+-					path = append(path, str[begin:end])
++					val := strings.Replace(str[begin:end], `\/`, `/`, -1)
++					path = append(path, val)
+ 				}
+ 				end++
+ 				begin = end


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
gnmi_set and gnmi_get does not support ip prefix with '/'.

#### How I did it
Update xpath to support escaped '/'.

#### How to verify it
Run unit test.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

