### PR TITLE
GCU is slower on arm platform, need to update time-out.

### DIFF
--- a/sonic_service_client/dbus_client.go
+++ b/sonic_service_client/dbus_client.go
@@ -114,7 +114,7 @@ func (c *DbusClient) ApplyPatchYang(fileName string) error {
 	busName := c.busNamePrefix + modName
 	busPath := c.busPathPrefix + modName
 	intName := c.intNamePrefix + modName + ".apply_patch_yang"
-	err := DbusApi(busName, busPath, intName, 10, fileName)
+	err := DbusApi(busName, busPath, intName, 60, fileName)
 	return err
 }
 
@@ -124,7 +124,7 @@ func (c *DbusClient) ApplyPatchDb(fileName string) error {
 	busName := c.busNamePrefix + modName
 	busPath := c.busPathPrefix + modName
 	intName := c.intNamePrefix + modName + ".apply_patch_db"
-	err := DbusApi(busName, busPath, intName, 10, fileName)
+	err := DbusApi(busName, busPath, intName, 60, fileName)
 	return err
 }
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Improve time out for GCU.

#### How I did it
Use 60 seconds for GCU DBUS interface.

#### How to verify it
Run gnmi_set command for incremental config update.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

