### PR TITLE
Reuse MixedDbClient to improve performance.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,11 +87,11 @@ check_gotest:
 	sudo cp ./testdata/database_config.json ${DBDIR}
 	sudo mkdir -p /usr/models/yang || true
 	sudo find $(MGMT_COMMON_DIR)/models -name '*.yang' -exec cp {} /usr/models/yang/ \;
-	sudo $(GO) test -coverprofile=coverage-config.txt -covermode=atomic -v github.com/sonic-net/sonic-gnmi/sonic_db_config
-	sudo $(GO) test -coverprofile=coverage-gnmi.txt -covermode=atomic -mod=vendor $(BLD_FLAGS) -v github.com/sonic-net/sonic-gnmi/gnmi_server -coverpkg ../...
-	sudo $(GO) test -coverprofile=coverage-dialcout.txt -covermode=atomic -mod=vendor $(BLD_FLAGS) -v github.com/sonic-net/sonic-gnmi/dialout/dialout_client
-	sudo $(GO) test -coverprofile=coverage-data.txt -covermode=atomic -mod=vendor -v github.com/sonic-net/sonic-gnmi/sonic_data_client
-	sudo $(GO) test -coverprofile=coverage-dbus.txt -covermode=atomic -mod=vendor -v github.com/sonic-net/sonic-gnmi/sonic_service_client
+	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(GO) test -coverprofile=coverage-config.txt -covermode=atomic -v github.com/sonic-net/sonic-gnmi/sonic_db_config
+	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(GO) test -coverprofile=coverage-gnmi.txt -covermode=atomic -mod=vendor $(BLD_FLAGS) -v github.com/sonic-net/sonic-gnmi/gnmi_server -coverpkg ../...
+	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(GO) test -coverprofile=coverage-dialcout.txt -covermode=atomic -mod=vendor $(BLD_FLAGS) -v github.com/sonic-net/sonic-gnmi/dialout/dialout_client
+	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(GO) test -coverprofile=coverage-data.txt -covermode=atomic -mod=vendor -v github.com/sonic-net/sonic-gnmi/sonic_data_client
+	sudo CGO_LDFLAGS="$(CGO_LDFLAGS)" CGO_CXXFLAGS="$(CGO_CXXFLAGS)" $(GO) test -coverprofile=coverage-dbus.txt -covermode=atomic -mod=vendor -v github.com/sonic-net/sonic-gnmi/sonic_service_client
 	$(GO) get github.com/axw/gocov/...
 	$(GO) get github.com/AlekSi/gocov-xml
 	gocov convert coverage-*.txt | gocov-xml -source $(shell pwd) > coverage.xml

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -7,7 +7,6 @@ import (
 	"reflect"
 	"io/ioutil"
 	"encoding/json"
-
 	"github.com/jipanyang/gnxi/utils/xpath"
 	"github.com/sonic-net/sonic-gnmi/swsscommon"
 	gnmipb "github.com/openconfig/gnmi/proto/gnmi"
@@ -381,7 +380,7 @@ func NativePerf(t *testing.T, client MixedDbClient, test string, table string, f
 func TestNativeWriteBatch(t *testing.T) {
 	var client MixedDbClient
 	client.target = "APPL_DB"
-	client.applDB = swsscommon.NewDBConnector2(APPL_DB, REDIS_SOCK, SWSS_TIMEOUT)
+	client.applDB = swsscommon.NewDBConnector(APPL_DB, REDIS_SOCK, SWSS_TIMEOUT)
 	client.tableMap = map[string]swsscommon.ProducerStateTable{}
 	tests := []struct {
 		name  string
@@ -417,3 +416,54 @@ func TestNativeWriteBatch(t *testing.T) {
 	}
 }
 
+func ReceiveFromZmq(consumer swsscommon.ZmqConsumerStateTable) (bool) {
+	receivedData := swsscommon.NewKeyOpFieldsValuesQueue()
+	retry := 0;
+	for {
+		time.Sleep(time.Duration(1000) * time.Millisecond)
+		consumer.Pops(receivedData)
+		if receivedData.Size() == 0 {
+			retry++
+			if retry >= 10 {
+				return false
+			}
+		} else {
+			return true
+		}
+	}
+}
+
+func TestZmqReconnect(t *testing.T) {
+	// create ZMQ server
+	db := swsscommon.NewDBConnector(APPL_DB_NAME, SWSS_TIMEOUT, false)
+	zmqServer := swsscommon.NewZmqServer("tcp://*:1234")
+	var TEST_TABLE string = "DASH_ROUTE"
+    consumer := swsscommon.NewZmqConsumerStateTable(db, TEST_TABLE, zmqServer)
+
+	// create ZMQ client side
+	zmqAddress := "tcp://127.0.0.1:1234"
+	client := MixedDbClient {
+		applDB : swsscommon.NewDBConnector(APPL_DB_NAME, SWSS_TIMEOUT, false),
+		tableMap : map[string]swsscommon.ProducerStateTable{},
+		zmqClient : swsscommon.NewZmqClient(zmqAddress),
+	}
+
+    data := map[string]string{}
+	var TEST_KEY string = "TestKey"
+	client.DbSetTable(TEST_TABLE, TEST_KEY, data)
+	if !ReceiveFromZmq(consumer) {
+		t.Errorf("Receive data from ZMQ failed")
+	}
+
+	// recreate ZMQ server to trigger re-connect
+    swsscommon.DeleteZmqConsumerStateTable(consumer)
+	swsscommon.DeleteZmqServer(zmqServer)
+	zmqServer = swsscommon.NewZmqServer("tcp://*:1234")
+    consumer = swsscommon.NewZmqConsumerStateTable(db, TEST_TABLE, zmqServer)
+
+	// send data again, client will reconnect
+	client.DbSetTable(TEST_TABLE, TEST_KEY, data)
+	if !ReceiveFromZmq(consumer) {
+		t.Errorf("Receive data from ZMQ failed")
+	}
+}

--- a/sonic_data_client/client_test.go
+++ b/sonic_data_client/client_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"io/ioutil"
 	"encoding/json"
+
 	"github.com/jipanyang/gnxi/utils/xpath"
 	"github.com/sonic-net/sonic-gnmi/swsscommon"
 	gnmipb "github.com/openconfig/gnmi/proto/gnmi"

--- a/sonic_data_client/mixed_db_client.go
+++ b/sonic_data_client/mixed_db_client.go
@@ -77,7 +77,7 @@ type MixedDbClient struct {
 
 var mixedDbClientMap = map[string]MixedDbClient{}
 
-func getMexedDbClient(zmqAddress string) (MixedDbClient) {
+func getMixedDbClient(zmqAddress string) (MixedDbClient) {
 	client, ok := mixedDbClientMap[zmqAddress]
 	if !ok {
 		client = MixedDbClient {
@@ -249,7 +249,7 @@ func NewMixedDbClient(paths []*gnmipb.Path, prefix *gnmipb.Path, zmqAddress stri
 		useRedisTcpClient()
 	}
 
-	var client = getMexedDbClient(zmqAddress)
+	var client = getMixedDbClient(zmqAddress)
 	client.prefix = prefix
 	client.target = ""
 	client.origin = ""

--- a/sonic_data_client/mixed_db_client.go
+++ b/sonic_data_client/mixed_db_client.go
@@ -173,12 +173,14 @@ func CatchException(err *error) {
 }
 
 func ProducerStateTableSetWrapper(pt swsscommon.ProducerStateTable, key string, value swsscommon.FieldValuePairs) (err error) {
+	// convert panic to error
 	defer CatchException(&err)
 	pt.Set(key, value, "SET", "")
 	return
 }
 
 func ProducerStateTableDeleteWrapper(pt swsscommon.ProducerStateTable, key string) (err error) {
+	// convert panic to error
 	defer CatchException(&err)
 	pt.Delete(key, "DEL", "")
 	return


### PR DESCRIPTION
Reuse MixedDbClient to improve performance.

#### Why I did it
Every API request will create a new MixedDbClient, also create ZMQ connection and table, which is not necessary.

#### How I did it
Add a cache to reuse MixedDbClient by ZMQ address.

#### How to verify it
Pass E2E test, create Dash resources correctly.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Reuse MixedDbClient to improve performance.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

