### PR TITLE
Change to use default orchange ZMQ port from sonic-swss-common

### DIFF
--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -7,10 +7,13 @@ import (
 	"io/ioutil"
 	"strconv"
 	"time"
+	"fmt"
 
 	log "github.com/golang/glog"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+
+	"github.com/sonic-net/sonic-gnmi/swsscommon"
 
 	gnmi "github.com/sonic-net/sonic-gnmi/gnmi_server"
 	testcert "github.com/sonic-net/sonic-gnmi/testdata/tls"
@@ -23,7 +26,7 @@ var (
 	caCert            = flag.String("ca_crt", "", "CA certificate for client certificate validation. Optional.")
 	serverCert        = flag.String("server_crt", "", "TLS server certificate")
 	serverKey         = flag.String("server_key", "", "TLS server private key")
-	zmqAddress        = flag.String("zmq_address", "tcp://localhost:1234", "ZMQ address")
+	zmqAddress        = flag.String("zmq_address", fmt.Sprintf("tcp://localhost:%s", swsscommon.GetORCH_ZMQ_PORT()), "ZMQ address")
 	insecure          = flag.Bool("insecure", false, "Skip providing TLS cert and key, for testing only!")
 	noTLS             = flag.Bool("noTLS", false, "disable TLS, for testing only!")
 	allowNoClientCert = flag.Bool("allow_no_client_auth", false, "When set, telemetry server will request but not require a client certificate.")

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -26,7 +26,7 @@ var (
 	caCert            = flag.String("ca_crt", "", "CA certificate for client certificate validation. Optional.")
 	serverCert        = flag.String("server_crt", "", "TLS server certificate")
 	serverKey         = flag.String("server_key", "", "TLS server private key")
-	zmqAddress        = flag.String("zmq_address", fmt.Sprintf("tcp://localhost:%s", swsscommon.GetORCH_ZMQ_PORT()), "ZMQ address")
+	zmqAddress        = flag.String("zmq_address", fmt.Sprintf("tcp://localhost:%d", swsscommon.GetORCH_ZMQ_PORT()), "ZMQ address")
 	insecure          = flag.Bool("insecure", false, "Skip providing TLS cert and key, for testing only!")
 	noTLS             = flag.Bool("noTLS", false, "disable TLS, for testing only!")
 	allowNoClientCert = flag.Bool("allow_no_client_auth", false, "When set, telemetry server will request but not require a client certificate.")


### PR DESCRIPTION
Change to use default orchange ZMQ port from sonic-swss-common

#### Why I did it
Default orchanget ZMQ port changed to 8020 and define moved to sonic-swss-common.

#### How I did it
Change to use default orchange ZMQ port from sonic-swss-common.

#### How to verify it
Pass E2E test, create Dash resources correctly.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Change to use default orchange ZMQ port from sonic-swss-common

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

