### PR TITLE
Improve code to switch ZmqProducerStateTable and Redis ProducerStateTable by zmq_address flag.

### DIFF
--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -21,7 +21,7 @@ var (
 	caCert            = flag.String("ca_crt", "", "CA certificate for client certificate validation. Optional.")
 	serverCert        = flag.String("server_crt", "", "TLS server certificate")
 	serverKey         = flag.String("server_key", "", "TLS server private key")
-	zmqAddress        = flag.String("zmq_address", "", "ZMQ address")
+	zmqAddress        = flag.String("zmq_address", "", "Orchagent ZMQ address, When not set or empty string telemetry server will switch to Redis based communication channel.")
 	insecure          = flag.Bool("insecure", false, "Skip providing TLS cert and key, for testing only!")
 	noTLS             = flag.Bool("noTLS", false, "disable TLS, for testing only!")
 	allowNoClientCert = flag.Bool("allow_no_client_auth", false, "When set, telemetry server will request but not require a client certificate.")

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -21,7 +21,7 @@ var (
 	caCert            = flag.String("ca_crt", "", "CA certificate for client certificate validation. Optional.")
 	serverCert        = flag.String("server_crt", "", "TLS server certificate")
 	serverKey         = flag.String("server_key", "", "TLS server private key")
-	zmqAddress        = flag.String("zmq_address", "", "Orchagent ZMQ address, When not set or empty string telemetry server will switch to Redis based communication channel.")
+	zmqAddress        = flag.String("zmq_address", "", "Orchagent ZMQ address, when not set or empty string telemetry server will switch to Redis based communication channel.")
 	insecure          = flag.Bool("insecure", false, "Skip providing TLS cert and key, for testing only!")
 	noTLS             = flag.Bool("noTLS", false, "disable TLS, for testing only!")
 	allowNoClientCert = flag.Bool("allow_no_client_auth", false, "When set, telemetry server will request but not require a client certificate.")

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -7,14 +7,9 @@ import (
 	"io/ioutil"
 	"strconv"
 	"time"
-	"fmt"
-
 	log "github.com/golang/glog"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-
-	"github.com/sonic-net/sonic-gnmi/swsscommon"
-
 	gnmi "github.com/sonic-net/sonic-gnmi/gnmi_server"
 	testcert "github.com/sonic-net/sonic-gnmi/testdata/tls"
 )
@@ -26,7 +21,7 @@ var (
 	caCert            = flag.String("ca_crt", "", "CA certificate for client certificate validation. Optional.")
 	serverCert        = flag.String("server_crt", "", "TLS server certificate")
 	serverKey         = flag.String("server_key", "", "TLS server private key")
-	zmqAddress        = flag.String("zmq_address", fmt.Sprintf("tcp://localhost:%d", swsscommon.GetORCH_ZMQ_PORT()), "ZMQ address")
+	zmqAddress        = flag.String("zmq_address", "", "ZMQ address")
 	insecure          = flag.Bool("insecure", false, "Skip providing TLS cert and key, for testing only!")
 	noTLS             = flag.Bool("noTLS", false, "disable TLS, for testing only!")
 	allowNoClientCert = flag.Bool("allow_no_client_auth", false, "When set, telemetry server will request but not require a client certificate.")
@@ -68,7 +63,7 @@ func main() {
 	cfg.EnableTranslibWrite = bool(*gnmi_translib_write)
 	cfg.EnableNativeWrite = bool(*gnmi_native_write)
 	cfg.LogLevel = 3
-	cfg.ZmqAddress = string(*zmqAddress)
+	cfg.ZmqAddress = *zmqAddress
 	var opts []grpc.ServerOption
 
 	if val, err := strconv.Atoi(getflag("v")); err == nil {


### PR DESCRIPTION
Improve code to switch ZmqProducerStateTable and Redis ProducerStateTable by zmq_address flag.

#### Why I did it
To provide compatibility, improve code to support switch ZmqProducerStateTable and Redis ProducerStateTable by zmq_address flag.

#### How I did it
Improve code to switch ZmqProducerStateTable and Redis ProducerStateTable by zmq_address flag.

#### How to verify it
Pass E2E test, create Dash resources correctly.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
Improve code to switch ZmqProducerStateTable and Redis ProducerStateTable by zmq_address flag.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

